### PR TITLE
Feature/sdk 260

### DIFF
--- a/jsvcgen/src/main/resources/codegen/java/TypeDefinition.ssp
+++ b/jsvcgen/src/main/resources/codegen/java/TypeDefinition.ssp
@@ -39,6 +39,8 @@ ${Util.layoutTemplate(options.headerTemplate.get, allSettings)}
 ${getCodeDocumentation( getClassDocumentation(value).take(1), "", Option.empty ) }
 ${accessModifier} class ${typeName} implements Serializable {
 
+    private static final long serialVersionUID = ${value.hashCode().toString.replace(",","")}L;
+
 #for (member <- value.members)
     private #if (immutableTypes)final #end ${getTypeName(member.typeUse)} ${getFieldName(member)};
 #end

--- a/jsvcgen/src/main/resources/codegen/java/TypeDefinition.ssp
+++ b/jsvcgen/src/main/resources/codegen/java/TypeDefinition.ssp
@@ -37,7 +37,7 @@ ${Util.layoutTemplate(options.headerTemplate.get, allSettings)}
 #end
 
 ${getCodeDocumentation( getClassDocumentation(value).take(1), "", Option.empty ) }
-${accessModifier} class ${typeName} {
+${accessModifier} class ${typeName} implements Serializable {
 
 #for (member <- value.members)
     private #if (immutableTypes)final #end ${getTypeName(member.typeUse)} ${getFieldName(member)};
@@ -128,7 +128,7 @@ ${toStringCalls};
         if(sb.lastIndexOf(", }") != -1)
             sb.deleteCharAt(sb.lastIndexOf(", }"));
 
-        return sb.result();
+        return sb.toString();
     }
 #end
 #if (value.name.endsWith("Request") && !value.members.isEmpty)

--- a/project/common.scala
+++ b/project/common.scala
@@ -149,7 +149,7 @@ object Version {
   val json4s     = "3.3.0"
   val scalate    = "1.7.1"
   val scopt      = "3.4.0"
-  val slf4j      = "1.7+"
+  val slf4j      = "1.6+"
   val junit      = "4.12"
   val scalatest  = "2.2.6"
   val scalacheck = "1.12+"


### PR DESCRIPTION
Adding the Serializable interface to all model, request and response objects.  Additionally create a serialVersionUID with the hashcode of the type definition. 

+ Downgraded slf4j to 1.6+ which is more compatible with existing libraries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/solidfire/jsvcgen/54)
<!-- Reviewable:end -->
