### PR TITLE
SDK-295 - Switch to use TLS instead of https in SSLContext

### DIFF
--- a/jsvcgen-client-java/src/main/java/com/solidfire/jsvcgen/client/HttpsRequestDispatcher.java
+++ b/jsvcgen-client-java/src/main/java/com/solidfire/jsvcgen/client/HttpsRequestDispatcher.java
@@ -110,18 +110,7 @@ public class HttpsRequestDispatcher implements RequestDispatcher {
 
     @Override
     public SSLContext getSSLContext() {
-        final SSLContext sslContext;
-        try {
-            sslContext = SSLContexts.custom()
-                                    .useProtocol("https")
-                                    .build();
-            return sslContext;
-        } catch (NoSuchAlgorithmException nsae) {
-            throw new RuntimeException("Couldn't get SSL from SSLContext", nsae);
-        } catch (KeyManagementException kme) {
-            throw new RuntimeException("Failed to initialize SSLContext", kme);
-        }
-
+        return SSLContexts.createDefault();
     }
 
     @Override


### PR DESCRIPTION
The removed code was unnecessary and wrong.  The protocol is 'TLS' not 'https' which is the default SSL Context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/solidfire/jsvcgen/63)
<!-- Reviewable:end -->
